### PR TITLE
Updates & Enhancements

### DIFF
--- a/ShapelessTable.scala
+++ b/ShapelessTable.scala
@@ -1,0 +1,25 @@
+package shapeless
+
+class Table[TH, TR](hdrs: TH, rows: TR*)
+
+object Table {
+  def apply[TH, TR](hdrs: TH, rows: TR*)
+                   (implicit ts: TableShape[TH, TR]) = new Table(hdrs, rows)
+
+  trait TableShape[TH, TR]
+
+  object TableShape {
+    implicit def productTableShape[TH, TR, LH, LR]
+    (implicit
+     genH: Generic.Aux[TH, LH],
+     genR: Generic.Aux[TR, LR],
+     hlistShape: TableShape[LH, LR]): TableShape[TH, TR] = new TableShape[TH, TR] {}
+
+    implicit def hsingleTableShape[RH]: TableShape[String :: HNil, RH :: HNil] =
+      new TableShape[String :: HNil, RH :: HNil] {}
+
+    implicit def hlistTableShape[HT <: HList, RH, RT <: HList]
+    (implicit tailShape: TableShape[HT, RT]): TableShape[String :: HT, RH :: RT] =
+      new TableShape[String :: HT, RH :: RT] {}
+  }
+}

--- a/ShapelessTable.scala
+++ b/ShapelessTable.scala
@@ -1,4 +1,6 @@
-package shapeless
+package shapelessTable
+
+import shapeless._
 
 class Table[TH, TR](hdrs: TH, rows: TR*)
 

--- a/allClassTestsInOneFile.scala
+++ b/allClassTestsInOneFile.scala
@@ -124,15 +124,15 @@ def generateSpecs2Immutable(testCount: Int, targetDir: File): File = {
 package iSpecification
         
 import org.specs2cls._
-                    
-class ExampleSpec extends SpecificationClass { def is =
-  "Scala can"  ^
-""")
-      
+
+class ExampleSpec extends SpecificationClass { def is =""" + "\n" +
+"  s2\"\"\"Scala can  ^"
+)
+
     for (x <- 1 to testCount)
-      targetOut.write("    \"increment " + x + "\"  ! e" + x + "^\n")
-     
-    targetOut.write("    end\n")
+      targetOut.write("    \"increment " + x + "\"  $e" + x + "^\n")
+
+    targetOut.write("    \"\"\"\n")
         
     for (x <- 1 to testCount) 
       targetOut.write("def e" + x + " = " + x + " + 1 must beEqualTo (" + (x+1) + ")\n")
@@ -309,7 +309,7 @@ if (scalaVersion != "unknown") {
   fileCountFile.write(headers)
   fileSizeFile.write(headers)
 
-  styles.foreach { style => 
+  styles.foreach { style =>
     testTypes.foreach { testType =>
       durationFile.write(style.name) // + " " + testType.name) Don't write with MustMatchers to get all 4 names to fit on graph
       durationFile.flush()

--- a/allClassTestsInOneFile.scala
+++ b/allClassTestsInOneFile.scala
@@ -67,8 +67,8 @@ def generateSourceFile(testCount: Int, targetDir: File, packageName: String, imp
 def assert2TestBodyFun(x: Int): String = "assert(" + x + " + 1 == " + (x+1) + ")"
 // Using assert(===)
 def assert3TestBodyFun(x: Int): String = "assert(" + x + " + 1 === " + (x+1) + ")"
-// Using must matchers
-def mustTestBodyFun(x: Int): String = x + " + 1 must be (" + (x+1) + ")"
+// Using should matchers
+def shouldTestBodyFun(x: Int): String = x + " + 1 should be (" + (x+1) + ")"
 
 // Spec 
 def specTestDefFun(x: Int): String = "def `increment " + x + "`"
@@ -277,7 +277,7 @@ if (scalaVersion != "unknown") {
 
   val testTypes = 
     Array(
-      TestType("with MustMatchers", "Must", Array("org.scalatest._", "matchers.MustMatchers._"), Array.empty, mustTestBodyFun)
+      TestType("with Matchers", "Should", Array("org.scalatest._", "Matchers._"), Array.empty, shouldTestBodyFun)
     )
 
   val testCounts = 
@@ -311,7 +311,7 @@ if (scalaVersion != "unknown") {
 
   styles.foreach { style =>
     testTypes.foreach { testType =>
-      durationFile.write(style.name) // + " " + testType.name) Don't write with MustMatchers to get all 4 names to fit on graph
+      durationFile.write(style.name) // + " " + testType.name) Don't write with Matchers to get all 4 names to fit on graph
       durationFile.flush()
       fileCountFile.write(style.name) // + " " + testType.name)
       fileCountFile.flush()

--- a/allTestsInOneFile.scala
+++ b/allTestsInOneFile.scala
@@ -124,15 +124,15 @@ def generateSpecs2Immutable(testCount: Int, targetDir: File): File = {
 package iSpecification
           
 import org.specs2._
-          
-class ExampleSpec extends Specification { def is =
-  "Scala can"  ^
-""")
-      
+
+class ExampleSpec extends Specification { def is =""" + "\n" +
+"  s2\"\"\"Scala can  ^"
+)
+
     for (x <- 1 to testCount)
-      targetOut.write("    \"increment " + x + "\"  ! e" + x + "^\n")
-     
-    targetOut.write("    end\n")
+      targetOut.write("    \"increment " + x + "\"  $e" + x + "^\n")
+
+    targetOut.write("    \"\"\"\n")
         
     for (x <- 1 to testCount) 
       targetOut.write("def e" + x + " = " + x + " + 1 must be equalTo (" + (x+1) + ")\n")
@@ -282,7 +282,7 @@ if (scalaVersion != "unknown") {
   fileCountFile.write(headers)
   fileSizeFile.write(headers)
 
-  styles.foreach { style => 
+  styles.foreach { style =>
     testTypes.foreach { testType =>
       durationFile.write(style.name) // + " " + testType.name) Don't write with MustMatchers to get all 4 names to fit on graph
       durationFile.flush()

--- a/allTestsInOneFile.scala
+++ b/allTestsInOneFile.scala
@@ -67,8 +67,8 @@ def generateSourceFile(testCount: Int, targetDir: File, packageName: String, imp
 def assert2TestBodyFun(x: Int): String = "assert(" + x + " + 1 == " + (x+1) + ")"
 // Using assert(===)
 def assert3TestBodyFun(x: Int): String = "assert(" + x + " + 1 === " + (x+1) + ")"
-// Using must matchers
-def mustTestBodyFun(x: Int): String = x + " + 1 must be (" + (x+1) + ")"
+// Using should matchers
+def shouldTestBodyFun(x: Int): String = x + " + 1 should be (" + (x+1) + ")"
 
 // Spec 
 def specTestDefFun(x: Int): String = "def `increment " + x + "`"
@@ -250,7 +250,7 @@ if (scalaVersion != "unknown") {
 
   val testTypes = 
     Array(
-      TestType("with MustMatchers", "Must", Array("org.scalatest._", "matchers.MustMatchers._"), Array.empty, mustTestBodyFun)
+      TestType("with Matchers", "Should", Array("org.scalatest._", "Matchers._"), Array.empty, shouldTestBodyFun)
     )
 
   val testCounts = 
@@ -284,7 +284,7 @@ if (scalaVersion != "unknown") {
 
   styles.foreach { style =>
     testTypes.foreach { testType =>
-      durationFile.write(style.name) // + " " + testType.name) Don't write with MustMatchers to get all 4 names to fit on graph
+      durationFile.write(style.name) // + " " + testType.name) Don't write with Matchers to get all 4 names to fit on graph
       durationFile.flush()
       fileCountFile.write(style.name) // + " " + testType.name)
       fileCountFile.flush()

--- a/assertTestsInOneFile.scala
+++ b/assertTestsInOneFile.scala
@@ -66,7 +66,7 @@ def generateSourceFile(testCount: Int, targetDir: File, packageName: String, imp
 // Using assert(===)
 def assert3TestBodyFun(x: Int): String = "assert(" + x + " + 1 === " + (x+1) + ")"
 // Using should matchers
-def mustTestBodyFun(x: Int): String = x + " + 1 should be (" + (x+1) + ")"
+def shouldTestBodyFun(x: Int): String = x + " + 1 should be (" + (x+1) + ")"
 
 // Spec 
 def specTestDefFun(x: Int): String = "def `increment " + x + "`"
@@ -164,8 +164,8 @@ if (scalaVersion != "unknown") {
   val testTypes = 
     Array(
       TestType("Triple Equal", "TripleEqual", Array("org.scalatest._"), Array.empty, assert3TestBodyFun), 
-      TestType("import ShouldMatchers", "ImportShould", Array("org.scalatest._", "matchers.ShouldMatchers._"), Array.empty, mustTestBodyFun), 
-      TestType("with ShouldMatchers", "MixinShould", Array("org.scalatest._"), Array("ShouldMatchers"), mustTestBodyFun)
+      TestType("import Matchers", "ImportMatchers", Array("org.scalatest._", "Matchers._"), Array.empty, shouldTestBodyFun),
+      TestType("with Matchers", "MixinMatchers", Array("org.scalatest._"), Array("Matchers"), shouldTestBodyFun)
     )
 
   val testCounts = 

--- a/assertTestsInOneFile.scala
+++ b/assertTestsInOneFile.scala
@@ -63,6 +63,8 @@ def generateSourceFile(testCount: Int, targetDir: File, packageName: String, imp
   targetFile
 }
 
+// Using assert(==)
+def assert2TestBodyFun(x: Int): String = "assert(" + x + " + 1 == " + (x+1) + ")"
 // Using assert(===)
 def assert3TestBodyFun(x: Int): String = "assert(" + x + " + 1 === " + (x+1) + ")"
 // Using should matchers
@@ -163,6 +165,7 @@ if (scalaVersion != "unknown") {
 
   val testTypes = 
     Array(
+      TestType("Double Equal", "DoubleEqual", Array("org.scalatest._"), Array.empty, assert2TestBodyFun),
       TestType("Triple Equal", "TripleEqual", Array("org.scalatest._"), Array.empty, assert3TestBodyFun), 
       TestType("import Matchers", "ImportMatchers", Array("org.scalatest._", "Matchers._"), Array.empty, shouldTestBodyFun),
       TestType("with Matchers", "MixinMatchers", Array("org.scalatest._"), Array("Matchers"), shouldTestBodyFun)

--- a/cleanem.sh
+++ b/cleanem.sh
@@ -1,2 +1,2 @@
 
-rm -rf allMethodTestsInOneFile allTestsInOneFile assertTestsInOneFile dataTables tenTestsPerFile testsIn100Files allClassTestsInOneFile
+rm -rf allMethodTestsInOneFile allTestsInOneFile assertTestsInOneFile dataTables tenTestsPerFile testsIn100Files allClassTestsInOneFile scalautilsScalaz

--- a/cleanem.sh
+++ b/cleanem.sh
@@ -1,2 +1,2 @@
 
-rm -rf allMethodTestsInOneFile allTestsInOneFile assertTestsInOneFile dataTables tenTestsPerFile testsIn100Files allClassTestsInOneFile scalautilsScalaz
+rm -rf allMethodTestsInOneFile allTestsInOneFile assertTestsInOneFile dataTables tenTestsPerFile testsIn100Files allClassTestsInOneFile scalautilsScalaz shapelessTables

--- a/dataTables.scala
+++ b/dataTables.scala
@@ -70,7 +70,7 @@ def generateSourceFile(testCount: Int, targetDir: File): File = {
     targetOut.write("import org.scalatest._\n")
     targetOut.write("import prop.TableDrivenPropertyChecks._\n\n")
     
-    targetOut.write("class ExampleSpec extends WordSpec with MustMatchers {\n\n")
+    targetOut.write("class ExampleSpec extends WordSpec with Matchers {\n\n")
     
     targetOut.write("  \"Scala\" can {\n")
     targetOut.write("    \"increment integers\" in {\n\n")
@@ -87,7 +87,7 @@ def generateSourceFile(testCount: Int, targetDir: File): File = {
     targetOut.write("        )\n\n")
     
     targetOut.write("      forAll(examples) { (left, right, sum) => \n")
-    targetOut.write("        left + right must be (sum)\n")
+    targetOut.write("        left + right should be (sum)\n")
     targetOut.write("      }\n")
     
     targetOut.write("    }\n")

--- a/google-chart.scala
+++ b/google-chart.scala
@@ -190,3 +190,10 @@ if (scalautilsScalazStatDir.exists)
   generateChartFile(scalautilsScalazStatDir, new File(scalautilsScalazDir, "scalautilsScalaz-graph.html"))
 else
   println("scalautilsScalaz/stat directory does not exist, scalautilsScalaz/scalautilsScalaz-graph.html will not be generated.")
+
+val shapelessTablesDir = new File("shapelessTables")
+val shapelessTablesStatDir = new File(shapelessTablesDir, "stat")
+if (shapelessTablesStatDir.exists)
+  generateChartFile(shapelessTablesStatDir, new File(shapelessTablesDir, "shapelessTables-graph.html"))
+else
+  println("shapelessTables/stat directory does not exist, shapelessTables/shapelessTables-graph.html will not be generated.")

--- a/google-chart.scala
+++ b/google-chart.scala
@@ -183,3 +183,10 @@ if (allClassTestsInOneFileStatDir.exists)
   generateChartFile(allClassTestsInOneFileStatDir, new File(allClassTestsInOneFileDir, "allClassTestsInOneFile-graph.html"))
 else
   println("allClassTestsInOneFile/stat directory does not exist, allClassTestsInOneFile/allClassTestsInOneFile-graph.html will not be generated.")
+
+val scalautilsScalazDir = new File("scalautilsScalaz")
+val scalautilsScalazStatDir = new File(scalautilsScalazDir, "stat")
+if (scalautilsScalazStatDir.exists)
+  generateChartFile(scalautilsScalazStatDir, new File(scalautilsScalazDir, "scalautilsScalaz-graph.html"))
+else
+  println("scalautilsScalaz/stat directory does not exist, scalautilsScalaz/scalautilsScalaz-graph.html will not be generated.")

--- a/runem.sh
+++ b/runem.sh
@@ -11,4 +11,5 @@ scala allMethodTestsInOneFile.scala
 scala assertTestsInOneFile.scala
 scala allClassTestsInOneFile.scala
 scala scalautilsScalaz.scala
+scala shapelessTables.scala
 scala google-chart.scala

--- a/runem.sh
+++ b/runem.sh
@@ -10,4 +10,5 @@ scala dataTables.scala
 scala allMethodTestsInOneFile.scala
 scala assertTestsInOneFile.scala
 scala allClassTestsInOneFile.scala
+scala scalautilsScalaz.scala
 scala google-chart.scala

--- a/runem.sh
+++ b/runem.sh
@@ -2,7 +2,7 @@ set -x
 JAVA_OPTS="-server -Xmx1024M -Xms128M"
 export JAVA_OPTS
 scala tenTestsPerFile.scala
-JAVA_OPTS="-server -Xmx2048M -Xms256M"
+JAVA_OPTS="-server -Xmx2048M -Xms256M -Xss6m"
 export JAVA_OPTS
 scala allTestsInOneFile.scala
 scala testsIn100Files.scala

--- a/scalautilsScalaz.scala
+++ b/scalautilsScalaz.scala
@@ -20,7 +20,7 @@ def downloadFile(urlString: String, targetFile: File) {
 }
 
 def generateSourceFile(testCount: Int, targetDir: File, packageName: String, importStatements: Array[String],
-                       testDefFun: (Int) => String, testBodyFun: (Int) => String): File = {
+                       equalFun: (Int) => String): File = {
   targetDir.mkdirs()
   val targetFile = new File(targetDir, "ExampleSpec.scala")
   val targetOut = new BufferedWriter(new FileWriter(targetFile))
@@ -31,11 +31,8 @@ def generateSourceFile(testCount: Int, targetDir: File, packageName: String, imp
     }
     targetOut.write("\n")
     targetOut.write("class ExampleSpec {\n")
-    for (x <- 1 to testCount) {
-      targetOut.write("    " + testDefFun(x) + " {\n")
-      targetOut.write("      " + testBodyFun(x) + "\n")
-      targetOut.write("    }\n")
-    }
+    for (x <- 1 to testCount)
+      targetOut.write("    " + equalFun(x) + "\n")
     targetOut.write("}\n")
   }
   finally {
@@ -45,9 +42,7 @@ def generateSourceFile(testCount: Int, targetDir: File, packageName: String, imp
   targetFile
 }
 
-def bodyFun(x: Int): String = x + " + 1 === " + (x+1)
-
-def defFun(x: Int): String = "def `increment " + x + "`"
+def equalFun(x: Int): String = x + " + 1 === " + (x+1)
 
 def compile(srcFile: String, classpath: String, targetDir: String) = {
   import scala.collection.JavaConversions._
@@ -181,8 +176,7 @@ testCounts.foreach { testCount =>
     new File(generatedDir, "scalautils"), // target dir
     "scalautils", // package name
     Array("org.scalautils.TypeCheckedTripleEquals._"), // imports
-    defFun,
-    bodyFun)
+    equalFun)
   val duration = compile(generatedSrc.getAbsolutePath, scalautilsClasspath, outputDir.getAbsolutePath)
   durationFile.write("," + duration)
   durationFile.flush()
@@ -218,8 +212,7 @@ testCounts.foreach { testCount =>
     new File(generatedDir, "scalaz"), // target dir
     "scalaz", // package name
     Array("Scalaz._"), // imports
-    defFun,
-    bodyFun)
+    equalFun)
   val duration = compile(generatedSrc.getAbsolutePath, scalazClasspath, outputDir.getAbsolutePath)
   durationFile.write("," + duration)
   durationFile.flush()

--- a/scalautilsScalaz.scala
+++ b/scalautilsScalaz.scala
@@ -1,0 +1,239 @@
+import java.net._
+import java.io._
+import java.nio.channels.Channels
+import scala.annotation.tailrec
+
+def scalaVersion = "2.10"
+val scalautilsVersion = "2.0"
+val scalazVersion = "7.0.4"
+
+def downloadFile(urlString: String, targetFile: File) {
+  println("Downloading " + urlString)
+  val url = new URL(urlString)
+  val connection = url.openConnection
+  val in = connection.getInputStream
+  val out = new FileOutputStream(targetFile)
+  out getChannel() transferFrom(Channels.newChannel(in), 0, Long.MaxValue)
+  in.close()
+  out.flush()
+  out.close()
+}
+
+def generateSourceFile(testCount: Int, targetDir: File, packageName: String, importStatements: Array[String],
+                       testDefFun: (Int) => String, testBodyFun: (Int) => String): File = {
+  targetDir.mkdirs()
+  val targetFile = new File(targetDir, "ExampleSpec.scala")
+  val targetOut = new BufferedWriter(new FileWriter(targetFile))
+  try {
+    targetOut.write("package " + packageName + "\n\n")
+    importStatements.foreach { s =>
+      targetOut.write("import " + s + "\n")
+    }
+    targetOut.write("\n")
+    targetOut.write("class ExampleSpec {\n")
+    for (x <- 1 to testCount) {
+      targetOut.write("    " + testDefFun(x) + " {\n")
+      targetOut.write("      " + testBodyFun(x) + "\n")
+      targetOut.write("    }\n")
+    }
+    targetOut.write("}\n")
+  }
+  finally {
+    targetOut.flush()
+    targetOut.close()
+  }
+  targetFile
+}
+
+def bodyFun(x: Int): String = x + " + 1 === " + (x+1)
+
+def defFun(x: Int): String = "def `increment " + x + "`"
+
+def compile(srcFile: String, classpath: String, targetDir: String) = {
+  import scala.collection.JavaConversions._
+
+  val command = List("scalac", "-classpath", classpath, "-d", targetDir, srcFile)
+  val builder = new ProcessBuilder(command)
+  builder.redirectErrorStream(true)
+  val start = System.currentTimeMillis
+  val process = builder.start()
+
+  val stdout = new BufferedReader(new InputStreamReader(process.getInputStream))
+
+  var line = "Compiling " + srcFile + "..."
+  while (line != null) {
+    println (line)
+    line = stdout.readLine
+  }
+
+  val end = System.currentTimeMillis
+  end - start
+}
+
+def getFileAndByteCount(srcDir: File) = {
+  @tailrec
+  def getFileAndByteCountAcc(dirList: Array[File], fileCount: Long, byteCount: Long): Tuple2[Long, Long] = {
+    val (files, subDirs) = dirList.partition(_.isFile)
+    val classFiles = files.filter(f => f.getName.endsWith(".class"))
+    val newFileCount = fileCount + classFiles.size
+    val newByteCount = byteCount + classFiles.map { f => f.length.toLong }.foldLeft(0l) { (a, b) => a + b }
+    if (subDirs.isEmpty)
+      (newFileCount, newByteCount)
+    else
+      getFileAndByteCountAcc(subDirs.flatMap(d => d.listFiles), newFileCount, newByteCount)
+  }
+  getFileAndByteCountAcc(srcDir.listFiles, 0l, 0l)
+}
+
+def deleteDir(targetDir: File) {
+  val children = targetDir.listFiles
+  if (children != null) {
+    targetDir.listFiles.foreach { child =>
+      if (child.isFile)
+        child.delete()
+      else
+        deleteDir(child)
+    }
+    targetDir.delete()
+  }
+  else
+    println("Unable to list files in " + targetDir.getAbsolutePath)
+}
+
+def getOutputDir(baseOutputDir: File, testCount: Int): File = {
+  val outputDirName = "output-" + testCount
+  val outputDir = new File(baseOutputDir, outputDirName)
+  outputDir.mkdirs()
+  outputDir
+}
+
+val scalautilsJar = new File("scalautils_" + scalaVersion + "-" + scalautilsVersion + ".jar")
+if (!scalautilsJar.exists)
+  downloadFile("https://oss.sonatype.org/content/repositories/releases/org/scalautils/scalautils_" + scalaVersion + "/" + scalautilsVersion + "/scalautils_" + scalaVersion + "-" + scalautilsVersion + ".jar", scalautilsJar)
+
+val scalazJar = new File("scalaz-core_" + scalaVersion + "-" + scalazVersion + ".jar")
+if (!scalazJar.exists)
+  downloadFile("https://oss.sonatype.org/content/repositories/releases/org/scalaz/scalaz-core_" + scalaVersion + "/" + scalazVersion + "/scalaz-core_" + scalaVersion + "-" + scalazVersion + ".jar", scalazJar)
+
+val baseDir = new File("scalautilsScalaz")
+if (baseDir.exists)
+  deleteDir(baseDir)
+
+val statDir = new File(baseDir, "stat")
+statDir.mkdirs()
+
+val durationFile = new FileWriter(new File(statDir, "duration.csv"))
+val fileCountFile = new FileWriter(new File(statDir, "filecount.csv"))
+val fileSizeFile = new FileWriter(new File(statDir, "filesize.csv"))
+
+val baseOutputDir = new File(baseDir, "output")
+baseOutputDir.mkdirs()
+
+val baseGeneratedDir = new File(baseDir, "generated")
+baseGeneratedDir.mkdirs()
+
+val scalautilsClasspath = scalautilsJar.getName
+val scalazClasspath = scalazJar.getName
+
+val testCounts =
+  Array(
+    0,
+    10,
+    20,
+    30,
+    40,
+    50,
+    60,
+    70,
+    80,
+    90,
+    100,
+    200,
+    300,
+    400,
+    500,
+    600,
+    700,
+    800,
+    900,
+    1000
+  )
+
+val headers = "TestCount," + testCounts.mkString(",") + "\n"
+durationFile.write(headers)
+fileCountFile.write(headers)
+fileSizeFile.write(headers)
+
+durationFile.write("scalautils")
+durationFile.flush()
+fileCountFile.write("scalautils")
+fileCountFile.flush()
+fileSizeFile.write("scalautils")
+fileSizeFile.flush()
+
+testCounts.foreach { testCount =>
+  println("Working on scalautils test count " + testCount + "...")
+  val outputDir = getOutputDir(baseOutputDir, testCount)
+  val generatedDir = new File(baseGeneratedDir, "generated-" + testCount)
+
+  val generatedSrc = generateSourceFile(
+    testCount,
+    new File(generatedDir, "scalautils"), // target dir
+    "scalautils", // package name
+    Array("org.scalautils.TypeCheckedTripleEquals._"), // imports
+    defFun,
+    bodyFun)
+  val duration = compile(generatedSrc.getAbsolutePath, scalautilsClasspath, outputDir.getAbsolutePath)
+  durationFile.write("," + duration)
+  durationFile.flush()
+
+  val (fileCount, fileSize) = getFileAndByteCount(new File(outputDir, "scalautils"))
+  fileCountFile.write("," + fileCount)
+  fileCountFile.flush()
+  fileSizeFile.write("," + fileSize)
+  fileSizeFile.flush()
+}
+
+durationFile.write("\n")
+durationFile.flush()
+fileCountFile.write("\n")
+fileCountFile.flush()
+fileSizeFile.write("\n")
+fileSizeFile.flush()
+
+durationFile.write("scalaz")
+durationFile.flush()
+fileCountFile.write("scalaz")
+fileCountFile.flush()
+fileSizeFile.write("scalaz")
+fileSizeFile.flush()
+
+testCounts.foreach { testCount =>
+  println("Working on scalaz test count " + testCount + "...")
+  val outputDir = getOutputDir(baseOutputDir, testCount)
+  val generatedDir = new File(baseGeneratedDir, "generated-" + testCount)
+
+  val generatedSrc = generateSourceFile(
+    testCount,
+    new File(generatedDir, "scalaz"), // target dir
+    "scalaz", // package name
+    Array("Scalaz._"), // imports
+    defFun,
+    bodyFun)
+  val duration = compile(generatedSrc.getAbsolutePath, scalazClasspath, outputDir.getAbsolutePath)
+  durationFile.write("," + duration)
+  durationFile.flush()
+
+  val (fileCount, fileSize) = getFileAndByteCount(new File(outputDir, "scalaz"))
+  fileCountFile.write("," + fileCount)
+  fileCountFile.flush()
+  fileSizeFile.write("," + fileSize)
+  fileSizeFile.flush()
+}
+
+durationFile.flush()
+durationFile.close()
+fileCountFile.flush()
+fileCountFile.close()
+fileSizeFile.flush()
+fileSizeFile.close()

--- a/shapelessTables.scala
+++ b/shapelessTables.scala
@@ -93,10 +93,10 @@ def generateShapelessSourceFile(testCount: Int, targetDir: File): File = {
   val sumColWidth = List(sumColValueWidth, sumColHeader.length).max
 
   try {
-    targetOut.write("package shapeless\n\n")
+    targetOut.write("package shapelessTables\n\n")
 
     targetOut.write("import org.scalatest._\n")
-    targetOut.write("import shapeless._\n\n")
+    targetOut.write("import shapelessTable._\n\n")
 
     targetOut.write("class ExampleSpec extends WordSpec with Matchers {\n\n")
 
@@ -325,12 +325,12 @@ try {
     val outputDir = getOutputDir(baseOutputDir, testCount)
     val generatedDir = new File(baseGeneratedDir, "generated-" + testCount)
 
-    val generatedSrc = generateShapelessSourceFile(testCount, new File(generatedDir, "shapeless"))
+    val generatedSrc = generateShapelessSourceFile(testCount, new File(generatedDir, "shapelessTables"))
     val duration = compile(generatedSrc.getAbsolutePath, shapelessClasspath, outputDir.getAbsolutePath)
     durationFile.write("," + duration)
     durationFile.flush()
 
-    val (fileCount, fileSize) = getFileAndByteCount(new File(outputDir, "shapeless"))
+    val (fileCount, fileSize) = getFileAndByteCount(new File(outputDir, "shapelessTables"))
     fileCountFile.write("," + fileCount)
     fileCountFile.flush()
     fileSizeFile.write("," + fileSize)

--- a/shapelessTables.scala
+++ b/shapelessTables.scala
@@ -1,0 +1,351 @@
+import java.net._
+import java.io._
+import java.nio.channels.Channels
+import scala.annotation.tailrec
+
+def scalaVersion = "2.10"
+val scalaTestVersion = "2.0"
+
+def downloadFile(urlString: String, targetFile: File) {
+  println("Downloading " + urlString)
+  val url = new URL(urlString)
+  val connection = url.openConnection
+  val in = connection.getInputStream
+  val out = new FileOutputStream(targetFile)
+  out getChannel() transferFrom(Channels.newChannel(in), 0, Long.MaxValue)
+  in.close()
+  out.flush()
+  out.close()
+}
+
+sealed trait Align
+object Left extends Align
+object Right extends Align
+
+def padValue(value: String, columnWidth:Int, align: Align): String = {
+  val padCount = columnWidth - value.length
+  require(padCount >= 0)
+  align match {
+    case Left =>
+      value + (" " * padCount)
+    case Right =>
+      (" " * padCount) + value
+  }
+}
+
+val leftColHeader = "\"left\""
+val rightColHeader = "\"right\""
+val sumColHeader = "\"sum\""
+
+def generateScalaTestSourceFile(testCount: Int, targetDir: File): File = {
+  targetDir.mkdirs()
+  val targetFile = new File(targetDir, "ExampleSpec.scala")
+  val targetOut = new BufferedWriter(new FileWriter(targetFile))
+
+  val leftColValueWidth = testCount.toString.length
+  val sumColValueWidth = (testCount + 1).toString.length
+  val leftColWidth = List(leftColValueWidth, leftColHeader.length).max
+  val rightColWidth = rightColHeader.length
+  val sumColWidth = List(sumColValueWidth, sumColHeader.length).max
+
+  try {
+    targetOut.write("package scalatest\n\n")
+
+    targetOut.write("import org.scalatest._\n")
+    targetOut.write("import prop.TableDrivenPropertyChecks._\n\n")
+
+    targetOut.write("class ExampleSpec extends WordSpec with Matchers {\n\n")
+
+    targetOut.write("  \"Scala\" can {\n")
+    targetOut.write("    \"increment integers\" in {\n\n")
+
+    targetOut.write("      val examples = \n")
+    targetOut.write("        Table(\n")
+
+    // print headers
+    targetOut.write("          (" + padValue(leftColHeader, leftColWidth, Left) + ", " + padValue(rightColHeader, rightColWidth, Left) + ", " + padValue(sumColHeader, sumColWidth, Left) + ")" + (if (testCount > 0) ", \n" else "\n"))
+    // print data rows
+    for (x <- 1 to testCount) {
+      targetOut.write("          (" + padValue(x.toString, leftColWidth, Right) + ", " + padValue("1", rightColWidth, Right) + ", " + padValue((x + 1).toString, sumColWidth, Right) + ")" + (if (x < testCount) ", \n" else "\n"))
+    }
+    targetOut.write("        )\n\n")
+
+    targetOut.write("    }\n")
+    targetOut.write("  }\n")
+    targetOut.write("}\n")
+  }
+  finally {
+    targetOut.flush()
+    targetOut.close()
+  }
+  targetFile
+}
+
+def generateShapelessSourceFile(testCount: Int, targetDir: File): File = {
+  targetDir.mkdirs()
+  val targetFile = new File(targetDir, "ExampleSpec.scala")
+  val targetOut = new BufferedWriter(new FileWriter(targetFile))
+
+  val leftColValueWidth = testCount.toString.length
+  val sumColValueWidth = (testCount + 1).toString.length
+  val leftColWidth = List(leftColValueWidth, leftColHeader.length).max
+  val rightColWidth = rightColHeader.length
+  val sumColWidth = List(sumColValueWidth, sumColHeader.length).max
+
+  try {
+    targetOut.write("package shapeless\n\n")
+
+    targetOut.write("import org.scalatest._\n")
+    targetOut.write("import shapeless._\n\n")
+
+    targetOut.write("class ExampleSpec extends WordSpec with Matchers {\n\n")
+
+    targetOut.write("  \"Scala\" can {\n")
+    targetOut.write("    \"increment integers\" in {\n\n")
+
+    targetOut.write("      val examples = \n")
+    targetOut.write("        Table(\n")
+
+    // print headers
+    targetOut.write("          (" + padValue(leftColHeader, leftColWidth, Left) + ", " + padValue(rightColHeader, rightColWidth, Left) + ", " + padValue(sumColHeader, sumColWidth, Left) + ")" + (if (testCount > 0) ", \n" else "\n"))
+    // print data rows
+    for (x <- 1 to testCount) {
+      targetOut.write("          (" + padValue(x.toString, leftColWidth, Right) + ", " + padValue("1", rightColWidth, Right) + ", " + padValue((x + 1).toString, sumColWidth, Right) + ")" + (if (x < testCount) ", \n" else "\n"))
+    }
+    targetOut.write("        )\n\n")
+
+    targetOut.write("    }\n")
+    targetOut.write("  }\n")
+    targetOut.write("}\n")
+  }
+  finally {
+    targetOut.flush()
+    targetOut.close()
+  }
+  targetFile
+}
+
+def compile(srcFile: String, classpath: String, targetDir: String) = {
+  import scala.collection.JavaConversions._
+
+  val command = List("scalac", "-classpath", classpath, "-d", targetDir, srcFile)
+  val builder = new ProcessBuilder(command)
+  builder.redirectErrorStream(true)
+  val start = System.currentTimeMillis
+  val process = builder.start()
+
+  val stdout = new BufferedReader(new InputStreamReader(process.getInputStream))
+
+  var line = "Compiling " + srcFile + "..."
+  while (line != null) {
+    println (line)
+    line = stdout.readLine
+  }
+
+  val end = System.currentTimeMillis
+  end - start
+}
+
+def jar(jarFileName: String, classesDir: String) = {
+  import scala.collection.JavaConversions._
+
+  val command = List("jar", "cf", jarFileName, "-C", classesDir, ".")
+  val builder = new ProcessBuilder(command)
+  builder.redirectErrorStream(true)
+  val start = System.currentTimeMillis
+  val process = builder.start()
+
+  val stdout = new BufferedReader(new InputStreamReader(process.getInputStream))
+
+  var line = "Creating jar file " + jarFileName + "..."
+  while (line != null) {
+    println (line)
+    line = stdout.readLine
+  }
+
+  val end = System.currentTimeMillis
+  end - start
+}
+
+def getFileAndByteCount(srcDir: File) = {
+  @tailrec
+  def getFileAndByteCountAcc(dirList: Array[File], fileCount: Long, byteCount: Long): Tuple2[Long, Long] = {
+    val (files, subDirs) = dirList.partition(_.isFile)
+    val classFiles = files.filter(f => f.getName.endsWith(".class"))
+    val newFileCount = fileCount + classFiles.size
+    val newByteCount = byteCount + classFiles.map { f => f.length.toLong }.foldLeft(0l) { (a, b) => a + b }
+    if (subDirs.isEmpty)
+      (newFileCount, newByteCount)
+    else
+      getFileAndByteCountAcc(subDirs.flatMap(d => d.listFiles), newFileCount, newByteCount)
+  }
+  getFileAndByteCountAcc(srcDir.listFiles, 0l, 0l)
+}
+
+def deleteDir(targetDir: File) {
+  val children = targetDir.listFiles
+  if (children != null) {
+    targetDir.listFiles.foreach { child =>
+      if (child.isFile)
+        child.delete()
+      else
+        deleteDir(child)
+    }
+    targetDir.delete()
+  }
+  else
+    println("Unable to list files in " + targetDir.getAbsolutePath)
+}
+
+def getOutputDir(baseOutputDir: File, testCount: Int): File = {
+  val outputDirName = "output-" + testCount
+  val outputDir = new File(baseOutputDir, outputDirName)
+  outputDir.mkdirs()
+  outputDir
+}
+
+val scalatestJar = new File("scalatest_" + scalaVersion + "-" + scalaTestVersion + ".jar")
+if (!scalatestJar.exists)
+  downloadFile("https://oss.sonatype.org/content/repositories/releases/org/scalatest/scalatest_" + scalaVersion + "/" + scalaTestVersion + "/scalatest_" + scalaVersion + "-" + scalaTestVersion + ".jar", scalatestJar)
+
+val shapelessJar = new File("shapeless_2.10.2-2.0.0-SNAPSHOT.jar")
+if (!shapelessJar.exists)
+  downloadFile("http://oss.sonatype.org/content/repositories/snapshots/com/chuusai/shapeless_2.10.2/2.0.0-SNAPSHOT/shapeless_2.10.2-2.0.0-SNAPSHOT.jar", shapelessJar)
+
+val baseDir = new File("shapelessTables")
+if (baseDir.exists)
+  deleteDir(baseDir)
+
+baseDir.mkdirs()
+
+val shapelessTableJar = new File("shapeless-table.jar")
+if (!shapelessTableJar.exists) {
+  val shapelessTableSource = new File("ShapelessTable.scala")
+  val shapelessTableClassDir = new File(baseDir, "shapeless-table")
+  shapelessTableClassDir.mkdirs()
+  compile(shapelessTableSource.getAbsolutePath, shapelessJar.getName, shapelessTableClassDir.getAbsolutePath)
+  jar(shapelessTableJar.getName, shapelessTableClassDir.getAbsolutePath)
+}
+
+val statDir = new File(baseDir, "stat")
+statDir.mkdirs()
+
+val durationFile = new FileWriter(new File(statDir, "duration.csv"))
+val fileCountFile = new FileWriter(new File(statDir, "filecount.csv"))
+val fileSizeFile = new FileWriter(new File(statDir, "filesize.csv"))
+
+val scalaTestClasspath = scalatestJar.getName
+
+val shapelessClasspath = scalatestJar.getName + File.pathSeparator + shapelessJar.getName + File.pathSeparator + shapelessTableJar.getName
+
+val baseOutputDir = new File(baseDir, "output")
+baseOutputDir.mkdirs()
+
+val baseGeneratedDir = new File(baseDir, "generated")
+baseGeneratedDir.mkdirs()
+
+val testCounts =
+  Array(
+    10,
+    20,
+    30,
+    40,
+    50,
+    60,
+    70,
+    80,
+    90,
+    100,
+    200,
+    300,
+    400,
+    500,
+    600,
+    700,
+    800,
+    900,
+    1000
+  )
+
+val headers = "TestCount," + testCounts.mkString(",") + "\n"
+durationFile.write(headers)
+fileCountFile.write(headers)
+fileSizeFile.write(headers)
+
+// ScalaTest Table
+durationFile.write("scalatest")
+durationFile.flush()
+fileCountFile.write("scalatest")
+fileCountFile.flush()
+fileSizeFile.write("scalatest")
+fileSizeFile.flush()
+
+try {
+  testCounts.foreach { testCount =>
+    println("Working on ScalaTest test count " + testCount + "...")
+    val outputDir = getOutputDir(baseOutputDir, testCount)
+    val generatedDir = new File(baseGeneratedDir, "generated-" + testCount)
+
+    val generatedSrc = generateScalaTestSourceFile(testCount, new File(generatedDir, "scalatest"))
+    val duration = compile(generatedSrc.getAbsolutePath, scalaTestClasspath, outputDir.getAbsolutePath)
+    durationFile.write("," + duration)
+    durationFile.flush()
+
+    val (fileCount, fileSize) = getFileAndByteCount(new File(outputDir, "scalatest"))
+    fileCountFile.write("," + fileCount)
+    fileCountFile.flush()
+    fileSizeFile.write("," + fileSize)
+    fileSizeFile.flush()
+  }
+}
+catch {
+  case e: Throwable =>
+    e.printStackTrace()
+}
+finally {
+  durationFile.write("\n")
+  durationFile.flush()
+  fileCountFile.write("\n")
+  fileCountFile.flush()
+  fileSizeFile.write("\n")
+  fileSizeFile.flush()
+}
+
+// Shapeless Table
+durationFile.write("shapeless")
+durationFile.flush()
+fileCountFile.write("shapeless")
+fileCountFile.flush()
+fileSizeFile.write("shapeless")
+fileSizeFile.flush()
+
+try {
+  testCounts.foreach { testCount =>
+    println("Working on Shapeless test count " + testCount + "...")
+    val outputDir = getOutputDir(baseOutputDir, testCount)
+    val generatedDir = new File(baseGeneratedDir, "generated-" + testCount)
+
+    val generatedSrc = generateShapelessSourceFile(testCount, new File(generatedDir, "shapeless"))
+    val duration = compile(generatedSrc.getAbsolutePath, shapelessClasspath, outputDir.getAbsolutePath)
+    durationFile.write("," + duration)
+    durationFile.flush()
+
+    val (fileCount, fileSize) = getFileAndByteCount(new File(outputDir, "shapeless"))
+    fileCountFile.write("," + fileCount)
+    fileCountFile.flush()
+    fileSizeFile.write("," + fileSize)
+    fileSizeFile.flush()
+  }
+}
+catch {
+  case e: Throwable =>
+    e.printStackTrace()
+}
+finally {
+  durationFile.write("\n")
+  durationFile.flush()
+  fileCountFile.write("\n")
+  fileCountFile.flush()
+  fileSizeFile.write("\n")
+  fileSizeFile.flush()
+}

--- a/tenTestsPerFile.scala
+++ b/tenTestsPerFile.scala
@@ -91,8 +91,8 @@ def generateMultipleSourceFiles(testCount: Int, maxTestCount:Int, targetDir: Fil
 def assert2TestBodyFun(x: Int): String = "assert(" + x + " + 1 == " + (x+1) + ")"
 // Using assert(===)
 def assert3TestBodyFun(x: Int): String = "assert(" + x + " + 1 === " + (x+1) + ")"
-// Using must matchers
-def mustTestBodyFun(x: Int): String = x + " + 1 must be (" + (x+1) + ")"
+// Using should matchers
+def shouldTestBodyFun(x: Int): String = x + " + 1 should be (" + (x+1) + ")"
 
 // Spec 
 def specTestDefFun(x: Int): String = "def `increment " + x + "`"
@@ -313,7 +313,7 @@ if (scalaVersion != "unknown") {
 
   val testTypes = 
     Array(
-      TestType("with MustMatchers", "Must", Array("org.scalatest._", "matchers.MustMatchers._"), Array.empty, mustTestBodyFun)
+      TestType("with Matchers", "Matchers", Array("org.scalatest._", "Matchers._"), Array.empty, shouldTestBodyFun)
     )
 
   val testCounts = 

--- a/tenTestsPerFile.scala
+++ b/tenTestsPerFile.scala
@@ -168,14 +168,14 @@ package iSpecification
           
 import org.specs2._
           
-class ExampleSpec""" + fileNumber + """ extends Specification { def is =
-  "Scala can"  ^
-""")
+class ExampleSpec""" + fileNumber + " extends Specification { def is =\n" +
+"  s2\"\"\"Scala can  ^"
+)
       
     for (x <- 1 to testCount)
-      targetOut.write("    \"increment " + x + "\"  ! e" + x + "^\n")
+      targetOut.write("    \"increment " + x + "\"  $e" + x + "^\n")
      
-    targetOut.write("    end\n")
+    targetOut.write("    \"\"\"\n")
         
     for (x <- 1 to testCount) 
       targetOut.write("def e" + x + " = " + x + " + 1 must be equalTo (" + (x+1) + ")\n")
@@ -345,7 +345,7 @@ if (scalaVersion != "unknown") {
   fileCountFile.write(headers)
   fileSizeFile.write(headers)
 
-  styles.foreach { style => 
+  styles.foreach { style =>
     testTypes.foreach { testType => 
       try {
         durationFile.write(style.name) // Don't write with MustMatchers to get all 4 names to fit on graph

--- a/testsIn100Files.scala
+++ b/testsIn100Files.scala
@@ -80,8 +80,8 @@ def generateMultipleSourceFiles(testCount: Int, targetDir: File, packageName: St
 def assert2TestBodyFun(x: Int): String = "assert(" + x + " + 1 == " + (x+1) + ")"
 // Using assert(===)
 def assert3TestBodyFun(x: Int): String = "assert(" + x + " + 1 === " + (x+1) + ")"
-// Using must matchers
-def mustTestBodyFun(x: Int): String = x + " + 1 must be (" + (x+1) + ")"
+// Using should matchers
+def shouldTestBodyFun(x: Int): String = x + " + 1 should be (" + (x+1) + ")"
 
 // Spec 
 def specTestDefFun(x: Int): String = "def `increment " + x + "`"
@@ -282,7 +282,7 @@ if (scalaVersion != "unknown") {
 
   val testTypes = 
     Array(
-      TestType("with MustMatchers", "Must", Array("org.scalatest._", "matchers.MustMatchers._"), Array.empty, mustTestBodyFun)
+      TestType("with Matchers", "Should", Array("org.scalatest._", "Matchers._"), Array.empty, shouldTestBodyFun)
     )
 
   val testCounts = 

--- a/testsIn100Files.scala
+++ b/testsIn100Files.scala
@@ -146,15 +146,15 @@ def generateSpecs2Immutable(testCount: Int, targetDir: File, fileNumber: Int): F
 package iSpecification
           
 import org.specs2._
-          
-class ExampleSpec""" + fileNumber + """ extends Specification { def is =
-  "Scala can"  ^
-""")
-      
+
+class ExampleSpec""" + fileNumber + " extends Specification { def is =\n" +
+"  s2\"\"\"Scala can  ^"
+)
+
     for (x <- 1 to testCount)
-      targetOut.write("    \"increment " + x + "\"  ! e" + x + "^\n")
-     
-    targetOut.write("    end\n")
+      targetOut.write("    \"increment " + x + "\"  $e" + x + "^\n")
+
+    targetOut.write("    \"\"\"\n")
         
     for (x <- 1 to testCount) 
       targetOut.write("def e" + x + " = " + x + " + 1 must be equalTo (" + (x+1) + ")\n")
@@ -305,7 +305,7 @@ if (scalaVersion != "unknown") {
   fileCountFile.write(headers)
   fileSizeFile.write(headers)
 
-  styles.foreach { style => 
+  styles.foreach { style =>
     testTypes.foreach { testType => 
       try {
         durationFile.write(style.name) // Don't write with MustMatchers to get all 4 names to fit on graph


### PR DESCRIPTION
-Use String interpolation for specs2 acceptance style.
-Changed MustMatchers to Matcher and use 'should' instead.
-Added -Xss6m to runem.sh, as it is required to compile specs2 source generated by dataTables.scala.
-Added double equal (==) assertion type to assertTestsInOneFile.scala.
-Added scalautilsScalaz.scala to measure compile time of === for scalautils vs scalaz.
-Added shapelessTables.scala to measure compile time overhead of experimental shapeless's table implementation.
